### PR TITLE
fix TypeError: staticmethod object is not callable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "thrift-fmt"
-version = "0.2.3"
+version = "0.2.5"
 description = "formart thrift file"
 authors = [
     {name = "alingse", email = "alingse@foxmail.com"},


### PR DESCRIPTION
here is the pipedream 

```bash
curl -F thrift=@tests/fixtures/simple.thrift https://eov9v3cpvy0z8du.m.pipedream.net
```

![截屏2022-06-28 下午11 09 27](https://user-images.githubusercontent.com/11423310/176223464-1e9285d3-fe69-496b-ae51-577ded727d50.png)

