### PR TITLE
Add field align for assign

### DIFF
--- a/tests/fmt_test.py
+++ b/tests/fmt_test.py
@@ -116,3 +116,18 @@ struct Work {
     # or only a single node
     header = PureThriftFormatter().format_node(thrift.document.children[0])
     assert header == 'include "shared.thrift"'
+
+def test_field_assign_align():
+    data = '''
+struct Work {
+1: i32 number_a = 0,
+2: required i32 num2 = 1,
+}
+'''
+
+    thrift = ThriftData.from_str(data)
+    out = ThriftFormatter(thrift).format()
+    assert out == '''struct Work {
+    1: required i32 number_a = 0,
+    2: required i32 num2 = 1,
+}'''

--- a/tests/fmt_test.py
+++ b/tests/fmt_test.py
@@ -120,14 +120,16 @@ struct Work {
 def test_field_assign_align():
     data = '''
 struct Work {
-1: i32 number_a = 0,
-2: required i32 num2 = 1,
+1: i32 number_a = 0, // hello
+2: required i32 num2 = 1,//xyz
 }
 '''
 
     thrift = ThriftData.from_str(data)
-    out = ThriftFormatter(thrift).format()
+    fmt = ThriftFormatter(thrift)
+    fmt.option(Option(field_align=True))
+    out = fmt.format()
     assert out == '''struct Work {
-    1: required i32 number_a = 0,
-    2: required i32 num2 = 1,
+    1: required i32 number_a = 0, // hello
+    2: required i32 num2     = 1, //xyz
 }'''

--- a/thrift_fmt/core.py
+++ b/thrift_fmt/core.py
@@ -262,6 +262,7 @@ class ThriftFormatter(PureThriftFormatter):
         self._data: ThriftData = data
         self._document: ThriftParser.DocumentContext = data.document
 
+        self._field_left_padding: int = 0
         self._field_comment_padding: int = 0
         self._last_token_index: int = -1
 

--- a/thrift_fmt/core.py
+++ b/thrift_fmt/core.py
@@ -351,8 +351,12 @@ class ThriftFormatter(PureThriftFormatter):
     @staticmethod
     def _split_field_define_assign(node: ParseTree):
         '''
-          split file to two parts
+          split field to [left, right]
+          field: '1: required i32 number_a = 0,'
+          left:  '1: required i32 number_a'
+          right: '= 0,'
         '''
+
         assert isinstance(node, ThriftParser.FieldContext)
         left = copy.copy(node)
         right = copy.copy(node)

--- a/thrift_fmt/core.py
+++ b/thrift_fmt/core.py
@@ -496,7 +496,7 @@ class ThriftFormatter(PureThriftFormatter):
         # add abrove comments
         self._line_comments(node)
 
-        # add field algin
+        # add field align
         if isinstance(node.parent, ThriftParser.FieldContext) and node.symbol.text == '=':
             self._padding(self._field_left_padding, ' ')
 

--- a/thrift_fmt/core.py
+++ b/thrift_fmt/core.py
@@ -20,6 +20,7 @@ class Option(object):
         self.indent: int = self.DEFAULT_INDENT
         if indent and indent > 0:
             self.indent = indent
+        self.field_align: bool = True
 
 class PureThriftFormatter(object):
 
@@ -260,7 +261,7 @@ class ThriftFormatter(PureThriftFormatter):
         self._data: ThriftData = data
         self._document: ThriftParser.DocumentContext = data.document
 
-        self._field_padding: int = 0
+        self._field_comment_padding: int = 0
         self._last_token_index: int = -1
 
     def format(self) -> str:
@@ -345,7 +346,7 @@ class ThriftFormatter(PureThriftFormatter):
         if is_last and isinstance(node.children[-1], ThriftParser.List_separatorContext):
             node.children.pop()
 
-    def _calc_subfields_padding(self, fields: List[ParseTree]):
+    def _calc_subfields_comment_padding(self, fields: List[ParseTree]):
         if not fields:
             return 0
 
@@ -357,10 +358,10 @@ class ThriftFormatter(PureThriftFormatter):
         return padding
 
     def before_subfields_hook(self, fields: List[ParseTree]):
-        self._field_padding = self._calc_subfields_padding(fields) + self._option.indent
+        self._field_comment_padding = self._calc_subfields_comment_padding(fields) + self._option.indent
 
     def after_subfields_hook(self, _: List[ParseTree]):
-        self._field_padding = 0
+        self._field_comment_padding = 0
 
     def after_block_node_hook(self, _: ParseTree):
         self._tail_comment()
@@ -416,9 +417,9 @@ class ThriftFormatter(PureThriftFormatter):
 
         assert len(comments) <= 1
         if comments:
-            if self._field_padding > 0:
+            if self._field_comment_padding > 0:
                 cur = len(self._out.getvalue().rsplit('\n', 1)[-1])
-                padding = self._field_padding - cur
+                padding = self._field_comment_padding - cur
                 if padding > 0:
                     self._append(' ' * padding)
 

--- a/thrift_fmt/core.py
+++ b/thrift_fmt/core.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import copy
 import io
 import typing
 from typing import List, Optional, Callable, Tuple
@@ -14,13 +15,13 @@ from thrift_parser.ThriftParser import ThriftParser
 class Option(object):
     DEFAULT_INDENT: int = 4
 
-    def __init__(self, patch :bool = True, comment :bool = True, indent :Optional[int] = None):
+    def __init__(self, patch :bool = True, comment :bool = True, indent :Optional[int] = None, field_align: bool=False):
         self.patch: bool = patch
         self.comment: bool = comment
         self.indent: int = self.DEFAULT_INDENT
         if indent and indent > 0:
             self.indent = indent
-        self.field_align: bool = True
+        self.field_align: bool = field_align
 
 class PureThriftFormatter(object):
 
@@ -346,25 +347,82 @@ class ThriftFormatter(PureThriftFormatter):
         if is_last and isinstance(node.children[-1], ThriftParser.List_separatorContext):
             node.children.pop()
 
-    def _calc_subfields_comment_padding(self, fields: List[ParseTree]):
-        if not fields:
-            return 0
+    @staticmethod
+    def _split_field_define_assign(node: ParseTree):
+        '''
+          split file to two parts
+        '''
+        assert isinstance(node, ThriftParser.FieldContext)
+        left = copy.copy(node)
+        right = copy.copy(node)
 
-        padding = 0
-        for field in fields:
-            out = PureThriftFormatter().format_node(field)
-            if len(out) > padding:
-                padding = len(out)
-        return padding
+        i = 0
+        for i, child in enumerate(node.children):
+            if isinstance(child, TerminalNodeImpl):
+                if child.symbol.text == '=':
+                    break
+
+        left.children = node.children[:i]
+        right.children = node.children[i:]
+        return left, right
+
+    def _calc_subfields_padding(self, fields: List[ParseTree]):
+        '''
+        field: '1: required i32 number_a = 0,'
+        left_padding:    field.index('=')
+        comment_padding: len(field)
+        '''
+        if not fields:
+            return 0, 0
+
+        if self._option.field_align:
+            # clac align padding
+            left_max_size = 0
+            right_max_size = 0
+            for field in fields:
+                left, right = self._split_field_define_assign(field)
+                left_size = len(PureThriftFormatter().format_node(left))
+                right_size = len(PureThriftFormatter().format_node(right))
+
+                left_max_size = max(left_max_size, left_size)
+                right_max_size = max(right_max_size, right_size)
+            # add extra space
+            left_padding = left_max_size + 1
+            comment_padding = left_max_size + 1 + right_max_size
+        else:
+            left_padding = 0
+
+            comment_padding = 0
+            for field in fields:
+                out = PureThriftFormatter().format_node(field)
+                if len(out) > comment_padding:
+                    comment_padding = len(out)
+
+        return left_padding, comment_padding
 
     def before_subfields_hook(self, fields: List[ParseTree]):
-        self._field_comment_padding = self._calc_subfields_comment_padding(fields) + self._option.indent
+        left_padding, comment_padding = self._calc_subfields_padding(fields)
+        self._field_left_padding = left_padding + self._option.indent
+        self._field_comment_padding = comment_padding + self._option.indent
 
     def after_subfields_hook(self, _: List[ParseTree]):
+        self._field_left_padding = 0
         self._field_comment_padding = 0
 
     def after_block_node_hook(self, _: ParseTree):
         self._tail_comment()
+
+    def _get_current_line(self):
+        cur = self._out.getvalue().rsplit('\n', 1)[-1]
+        return cur
+
+    def _padding(self, padding: int, pad: str=' '):
+        if padding <= 0:
+            return
+        cur = self._get_current_line()
+        padding = padding - len(cur)
+        if padding > 0:
+            self._append(pad * padding)
 
     def _line_comments(self, node: TerminalNodeImpl):
         if not self._option.comment:
@@ -417,12 +475,7 @@ class ThriftFormatter(PureThriftFormatter):
 
         assert len(comments) <= 1
         if comments:
-            if self._field_comment_padding > 0:
-                cur = len(self._out.getvalue().rsplit('\n', 1)[-1])
-                padding = self._field_comment_padding - cur
-                if padding > 0:
-                    self._append(' ' * padding)
-
+            self._padding(self._field_comment_padding, ' ')
             self._append(' ')
             self._append(comments[0].text.strip())
             self._push('')
@@ -437,5 +490,9 @@ class ThriftFormatter(PureThriftFormatter):
 
         # add abrove comments
         self._line_comments(node)
+
+        # add field algin
+        if isinstance(node.parent, ThriftParser.FieldContext) and node.symbol.text == '=':
+            self._padding(self._field_left_padding, ' ')
 
         super().TerminalNodeImpl(node)


### PR DESCRIPTION
```thrift
struct Work {
1: i32 number_a = 0, // hello
2: required i32 num2 = 1,//xyz
}
```
will format to

```thrift
struct Work {
    1: required i32 number_a = 0, // hello
    2: required i32 num2     = 1, //xyz
}
```